### PR TITLE
fix wrong score_all being loaded in load_file

### DIFF
--- a/compute_eer_bac.py
+++ b/compute_eer_bac.py
@@ -28,7 +28,7 @@ def load_file(score, trial):
         else:
             nontarget_score.append(score_all[ind_])
     score_all = np.array(score_all)
-    return np.array(target_score), np.array(nontarget_score), np.reshape(score_all, (2,-1))
+    return np.array(target_score), np.array(nontarget_score), np.reshape(score_all, (-1, 2)).T
 
 
 def pavx(y):


### PR DESCRIPTION
Hi,

`load_file` function seems to be loading incorrect scores. For example if score file contains:

> file_1 0.9 0.1
> file_2 0.3 0.7
> file_3 0.2 0.8

Then the older function will return following as `score_all`
```py
array([[0.9, 0.1, 0.3],
       [0.7, 0.2, 0.8]])
```

while the expected `score_all` should be (which is fixed in this PR | kindly verify before merge):

```py
array([[0.9, 0.3, 0.2],
       [0.1, 0.7, 0.8]])
```

Thanks!
